### PR TITLE
changed to lts version of ROS (Foxy)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG FROM_IMAGE=ros:galactic
+ARG FROM_IMAGE=ros:foxy
 ARG OVERLAY_WS=/opt/ros/dev_ws
 
 # multi-stage for caching
@@ -25,7 +25,7 @@ RUN apt -y upgrade
 RUN apt install -y build-essential net-tools vim wget
 RUN apt install -y nano
 RUN apt install -y python3-pip
-RUN apt install -y ~nros-galactic-rqt*
+RUN apt install -y ros-foxy-rqt*
 
 RUN pip3 install Cython
 RUN pip3 install sbp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,14 +10,14 @@ services:
                         - /dev:/dev
                         - ./.bashrc-docker:/root/.bashrc
                         - ./ros_packages/:/opt/ros/dev_ws/src
-                image: "dev_image:galactic"
+                image: "dev_image:foxy"
                 tty: true
                 stdin_open: true
                 container_name: "dev"
                 privileged: true
         uros:
-                image: "microros/micro-ros-agent:galactic"
-                command: serial --dev TEENSYNAME
+                image: "microros/micro-ros-agent:foxy"
+                command: serial --dev <TEENSYNAME>
                 volumes:
                         - /dev:/dev
                 container_name: "uros"


### PR DESCRIPTION
Needed to switch back to Foxy to maintain compatibility with other microros packages and ensure stability. Foxy is an LTS (long time support) and will be supported for longer than Galactic.